### PR TITLE
Extend Jest unit tests for services

### DIFF
--- a/front/src/app/features/auth/services/auth.service.spec.ts
+++ b/front/src/app/features/auth/services/auth.service.spec.ts
@@ -1,22 +1,24 @@
-import { HttpClientModule, HttpClient } from '@angular/common/http';
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 import { TestBed } from '@angular/core/testing';
 import { expect } from '@jest/globals';
-import { of } from 'rxjs';
+
 import { AuthService } from './auth.service';
-import { LoginRequest } from '../interfaces/loginRequest.interface';
-import { RegisterRequest } from '../interfaces/registerRequest.interface';
-import { SessionInformation } from 'src/app/interfaces/sessionInformation.interface';
+import { mockSessionInformation } from '../../../mocks/session.information.mocks';
+import { mockRegisterRequest, mockLoginRequest } from '../../../mocks/auth.mocks';
 
 describe('AuthService', () => {
   let service: AuthService;
-  let httpClient: HttpClient;
+  let httpTestingController: HttpTestingController;
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [HttpClientModule]
+      imports: [
+        HttpClientTestingModule
+      ]
     });
+
     service = TestBed.inject(AuthService);
-    httpClient = TestBed.inject(HttpClient);
+    httpTestingController = TestBed.inject(HttpTestingController);
   });
 
   it('should be created', () => {
@@ -24,44 +26,53 @@ describe('AuthService', () => {
   });
 
   it('should call POST /api/auth/register with RegisterRequest and return void', () => {
-    const mockRegisterRequest: RegisterRequest = { 
-      email: 'claire@perret.com',
-      firstName: 'Claire',
-      lastName: 'Perret',
-      password: 'password'
-    };
-
-    const httpPostSpy = jest.spyOn(httpClient, 'post').mockReturnValue(of(undefined));
-
     service.register(mockRegisterRequest).subscribe((result) => {
       expect(result).toBeUndefined();
     });
 
-    expect(httpPostSpy).toHaveBeenCalledWith('api/auth/register', mockRegisterRequest);
+    const req = httpTestingController.expectOne('api/auth/register');
+    expect(req.request.method).toBe('POST');
+    req.flush(null);
+  });
+
+  it('should handle bad request error on POST /api/auth/register', () => {
+    service.register(mockRegisterRequest).subscribe({
+      next: () => {
+        throw new Error('Expected error, but got success');
+      },
+      error: (error) => {
+        expect(error.status).toBe(400);
+      }
+    });
+
+    const req = httpTestingController.expectOne('api/auth/register');
+    expect(req.request.method).toBe('POST');
+    req.flush('Bad Request', { status: 400, statusText: 'Bad Request' });
   });
 
   it('should call POST /api/auth/login with LoginRequest and return SessionInformation', () => {
-    const mockLoginRequest: LoginRequest = { 
-      email: 'claire@perret.com',
-      password: 'password'
-    };
-
-    const mockSessionInformation: SessionInformation = {
-      token: 'token',
-      type: 'type',
-      id: 1,
-      username: 'claire@perret.com',
-      firstName: 'Claire',
-      lastName: 'Perret',
-      admin: false
-    };
-
-    const httpPostSpy = jest.spyOn(httpClient, 'post').mockReturnValue(of(mockSessionInformation));
-
     service.login(mockLoginRequest).subscribe((result) => {
     expect(result).toEqual(mockSessionInformation);
     });
 
-    expect(httpPostSpy).toHaveBeenCalledWith('api/auth/login', mockLoginRequest);
+    const req = httpTestingController.expectOne('api/auth/login');
+    expect(req.request.method).toBe('POST');
+    req.flush(mockSessionInformation);
+  });
+
+  it('should handle an unauthorized error on POST /api/auth/login with wrong credentials', () => {
+    service.login(mockLoginRequest).subscribe({
+      next: () => {
+        throw new Error('Expected an error, but got a response');
+      },
+      error: (error) => {
+        expect(error.status).toBe(401);
+        expect(error.statusText).toBe('Unauthorized');
+      }
+    });
+
+    const req = httpTestingController.expectOne('api/auth/login');
+    expect(req.request.method).toBe('POST');
+    req.flush('Invalid credentials', { status: 401, statusText: 'Unauthorized' });
   });
 });

--- a/front/src/app/features/sessions/services/session-api.service.spec.ts
+++ b/front/src/app/features/sessions/services/session-api.service.spec.ts
@@ -1,170 +1,309 @@
-import { HttpClientModule, HttpClient } from '@angular/common/http';
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 import { TestBed } from '@angular/core/testing';
 import { expect } from '@jest/globals';
-import { firstValueFrom, of, throwError } from 'rxjs';
+
 import { SessionApiService } from './session-api.service';
-import { Session } from '../interfaces/session.interface';
+import { mockSession, mockSessions } from '../../../mocks/session.mocks';
 
 describe('SessionsService', () => {
   let service: SessionApiService;
-  let httpClient: HttpClient;
+  let httpTestingController: HttpTestingController;
 
   beforeEach(() => {
     TestBed.configureTestingModule({
       imports:[
-        HttpClientModule
+        HttpClientTestingModule
       ]
     });
+    
     service = TestBed.inject(SessionApiService);
-    httpClient = TestBed.inject(HttpClient);
+    httpTestingController = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpTestingController.verify();
   });
 
   it('should be created', () => {
     expect(service).toBeTruthy();
   });
 
-  it('should call GET /api/session and return all sessions', () => {
-    const mockSessions: Session[] = [
-      {
-        id: 1,
-        name: 'Session 1',
-        description: 'A session description 1',
-        date: new Date(),
-        teacher_id: 1,
-        users: [1, 2],
-        createdAt: new Date(),
-        updatedAt: new Date()
-      },
-      {
-        id: 2,
-        name: 'Session 2',
-        description: 'A session description 2',
-        date: new Date(),
-        teacher_id: 1,
-        users: [3, 4],
-        createdAt: new Date(),
-        updatedAt: new Date()
-      },
-      {
-        id: 3,
-        name: 'Session 3',
-        description: 'A session description 3',
-        date: new Date(),
-        teacher_id: 1,
-        users: [5, 6],
-        createdAt: new Date(),
-        updatedAt: new Date()
-      }
-    ];
+  // test for method : all()
+  describe('method: all()', () => {
+    it('should call GET /api/session and return all sessions', () => {
+      service.all().subscribe((sessions) => {
+        expect(sessions).toEqual(mockSessions);
+      });
 
-    const httpGetSpy = jest.spyOn(httpClient, 'get').mockReturnValue(of(mockSessions));
-
-    service.all().subscribe((result) => {
-      expect(result).toEqual(mockSessions);
+      const req = httpTestingController.expectOne('api/session');
+      expect(req.request.method).toBe('GET');
+      req.flush(mockSessions);
     });
-
-    expect(httpGetSpy).toHaveBeenCalledWith('api/session');
   });
   
-  it('should call GET /api/session/:id and return mockSession', () => {
-    const mockSession: Session = {
-      id: 1,
-      name: 'Session',
-      description: 'A session description',
-      date: new Date(),
-      teacher_id: 1,
-      users: [1, 2],
-      createdAt: new Date(),
-      updatedAt: new Date()
-    };
+  // tests for method: detail(id: string)
+  describe('method: detail(id: string)', () => {
+    it('should call GET /api/session/:id and return mockSession', () => {
+      service.detail('1').subscribe((session) => {
+        expect(session).toEqual(mockSession);
+      });
 
-    const httpGetSpy = jest.spyOn(httpClient, 'get').mockReturnValue(of(mockSession));
-
-    service.detail('1').subscribe((result) => {
-      expect(result).toEqual(mockSession);
+      const req = httpTestingController.expectOne('api/session/1');
+      expect(req.request.method).toBe('GET');
+      req.flush(mockSession);
     });
 
-    expect(httpGetSpy).toHaveBeenCalledWith('api/session/1');
-  });
+    it('should handle wrong id on GET /api/session/:id', () => {
+      service.detail('abc').subscribe({
+        next: () => {
+          throw new Error('Expected an error, but got a response');
+        },
+        error: (error) => {
+          expect(error.status).toBe(400);
+        }
+      });
 
-  it('should call DELETE /api/session/:id and return null', () => {
-    const httpDeleteSpy = jest.spyOn(httpClient, 'delete').mockReturnValue(of(null));
-
-    service.delete('1').subscribe((result) => {
-      expect(result).toBeNull();
+      const req = httpTestingController.expectOne('api/session/abc');
+      expect(req.request.method).toBe('GET');
+      req.flush('Bad Request', { status: 400, statusText: 'Bad Request' });
     });
 
-    expect(httpDeleteSpy).toHaveBeenCalledWith('api/session/1');
+    it('should handle 404 error on GET /api/session/:id when session not found', () => {
+      service.detail('9999').subscribe({
+        next: () => {
+          throw new Error('Expected an error, but got a response');
+        },
+        error: (error) => {
+          expect(error.status).toBe(404);
+          expect(error.statusText).toBe('Not Found');
+        }
+      });
+
+      const req = httpTestingController.expectOne('api/session/9999');
+      expect(req.request.method).toBe('GET');
+      req.flush('Session not found', { status: 404, statusText: 'Not Found' });
+    });
   });
 
-  it('should DELETE /api/session/:id a non-existent session and return an error', async () => {
-    const error = new Error('Delete failed');
-    jest.spyOn(httpClient, 'delete').mockReturnValue(throwError(() => error));
+  // tests for method: delete(id: string)
+  describe('method: delete(id: string)', () => {
+    it('should call DELETE /api/session/:id and return null', () => {
+      service.delete('1').subscribe((result) => {
+        expect(result).toBeNull();
+      });
 
-    await expect(firstValueFrom(service.delete('9999'))).rejects.toBe(error);
-
-    expect(httpClient.delete).toHaveBeenCalledWith('api/session/9999');
-  });
-
-  it('should call POST /api/session and create a session', () => {
-    const mockSession: Session = { 
-      id: 1,
-      name: 'Session',
-      description: 'A session description',
-      date: new Date(),
-      teacher_id: 1,
-      users: [1, 2],
-      createdAt: new Date(),
-      updatedAt: new Date()
-    };
-
-    const httpPostSpy = jest.spyOn(httpClient, 'post').mockReturnValue(of(mockSession));
-
-    service.create(mockSession).subscribe((result) => {
-      expect(result).toEqual(mockSession);
+      const req = httpTestingController.expectOne('api/session/1');
+      expect(req.request.method).toBe('DELETE');
+      req.flush(null);
     });
 
-    expect(httpPostSpy).toHaveBeenCalledWith('api/session', mockSession);
-  });
+    it('should handle wrong id on DELETE /api/session/:id', () => {
+      service.delete('abc').subscribe({
+        next: () => {
+          throw new Error('Expected an error, but got a response');
+        },
+        error: (error) => {
+          expect(error.status).toBe(400);
+        }
+      });
 
-  it('should call PUT /api/session/:id and update a session', () => {
-  const mockSession: Session = { 
-      id: 1,
-      name: 'Session',
-      description: 'A different session description',
-      date: new Date(),
-      teacher_id: 1,
-      users: [2, 3],
-      createdAt: new Date(),
-      updatedAt: new Date()
-    };
-
-    const httpPutSpy = jest.spyOn(httpClient, 'put').mockReturnValue(of(mockSession));
-
-    service.update('1', mockSession).subscribe((result) => {
-      expect(result).toEqual(mockSession);
+      const req = httpTestingController.expectOne('api/session/abc');
+      expect(req.request.method).toBe('DELETE');
+      req.flush('Bad Request', { status: 400, statusText: 'Bad Request' });
     });
 
-    expect(httpPutSpy).toHaveBeenCalledWith('api/session/1', mockSession);
+    it('should handle 404 error on DELETE /api/session/:id when session not found', () => {
+      service.delete('9999').subscribe({
+        next: () => {
+          throw new Error('Expected an error, but got a response');
+        },
+        error: (error) => {
+          expect(error.status).toBe(404);
+          expect(error.statusText).toBe('Not Found');
+        }
+      });
+
+      const req = httpTestingController.expectOne('api/session/9999');
+      expect(req.request.method).toBe('DELETE');
+      req.flush('Session not found', { status: 404, statusText: 'Not Found' });
+    });
   });
 
-  it('should call POST /api/session/:id/participate/:userId and add a user to a session', () => {
-    const httpPostSpy = jest.spyOn(httpClient, 'post').mockReturnValue(of(undefined));
+  // tests for method: create(session: Session)
+  describe('method: create(session: Session)', () => {
+    it('should call POST /api/session and create a session', () => {
+      service.create(mockSession).subscribe((session) => {
+        expect(session).toEqual(mockSession);
+      });
 
-    service.participate('1', '3').subscribe((result) => {
-      expect(result).toBeUndefined();
+      const req = httpTestingController.expectOne('api/session');
+      expect(req.request.method).toBe('POST');
+      req.flush(mockSession);
     });
 
-    expect(httpPostSpy).toHaveBeenCalledWith('api/session/1/participate/3', null);
+    it('should handle a bad request error on POST /api/session', () => {
+      service.create(mockSession).subscribe({
+        next: () => {
+          throw new Error('Expected an error, but got a response');
+        },
+        error: (error) => {
+          expect(error.status).toBe(400);
+        }
+      });
+
+      const req = httpTestingController.expectOne('api/session');
+      expect(req.request.method).toBe('POST');
+      req.flush('Bad Request', { status: 400, statusText: 'Bad Request' });
+    });
   });
 
-  it('should call DELETE /api/session/:id/participate/:userId and delete a user from a session', () => {
-    const httpDeleteSpy = jest.spyOn(httpClient, 'delete').mockReturnValue(of(null));
+  // tests for method: update(id: string, session: Session)
+  describe('method: update(id: string, session: Session)', () => {
+    it('should call PUT /api/session/:id and update a session', () => {
+      service.update('1', mockSession).subscribe((result) => {
+        expect(result).toEqual(mockSession);
+      });
 
-    service.unParticipate('1','3').subscribe((result) => {
-      expect(result).toBeUndefined();
+      const req = httpTestingController.expectOne('api/session/1');
+      expect(req.request.method).toBe('PUT');
+      req.flush(mockSession);
     });
 
-    expect(httpDeleteSpy).toHaveBeenCalledWith('api/session/1/participate/3');
+    it('should handle a session not found error on PUT /api/session/:id', () => {
+      service.update('1', mockSession).subscribe({
+        next: () => {
+          throw new Error('Expected an error, but got a response');
+        },
+        error: (error) => {
+          expect(error.status).toBe(404);
+        }
+      });
+
+      const req = httpTestingController.expectOne('api/session/1');
+      expect(req.request.method).toBe('PUT');
+      req.flush('Not Found', { status: 404, statusText: 'Not Found' });
+    });
+  });
+
+  // tests for method: participate(id: string, userId: string)
+  describe('method: participate(id: string, userId: string)', () => {
+    it('should call POST /api/session/:id/participate/:userId and add a user to a session', () => {
+      service.participate('1', '3').subscribe((result) => {
+        expect(result).toBeUndefined();
+      });
+
+      const req = httpTestingController.expectOne('api/session/1/participate/3');
+      expect(req.request.method).toBe('POST');
+      req.flush(null);
+    });
+
+    it('should handle a bad request error on POST /api/session/:id/participate/:userId with wrong userId', () => {
+      service.participate('1', 'abc').subscribe({
+        next: () => {
+          throw new Error('Expected an error, but got a response');
+        },
+        error: (error) => {
+          expect(error.status).toBe(400);
+          expect(error.statusText).toBe('Bad Request');
+        }
+      });
+
+      const req = httpTestingController.expectOne('api/session/1/participate/abc');
+      expect(req.request.method).toBe('POST');
+      req.flush('Invalid user ID', { status: 400, statusText: 'Bad Request' });
+    });
+
+    it('should handle a session not found error on POST /api/session/:id/participate/:userId', () => {
+      service.participate('9999', '3').subscribe({
+        next: () => {
+          throw new Error('Expected an error, but got a response');
+        },
+        error: (error) => {
+          expect(error.status).toBe(404);
+          expect(error.statusText).toBe('Not Found');
+        }
+      });
+
+      const req = httpTestingController.expectOne('api/session/9999/participate/3');
+      expect(req.request.method).toBe('POST');
+      req.flush('Session not found', { status: 404, statusText: 'Not Found' });
+    });
+
+    it('should handle a user not found error on POST /api/session/:id/participate/:userId', () => {
+      service.participate('1', '9999').subscribe({
+        next: () => {
+          throw new Error('Expected an error, but got a response');
+        },
+        error: (error) => {
+          expect(error.status).toBe(404);
+          expect(error.statusText).toBe('Not Found');
+        }
+      });
+
+      const req = httpTestingController.expectOne('api/session/1/participate/9999');
+      expect(req.request.method).toBe('POST');
+      req.flush('Session not found', { status: 404, statusText: 'Not Found' });
+    });
+  });
+
+  // tests for method: unParticipate(id: string, userId: string)
+  describe('method: unParticipate(id: string, userId: string)', () => {
+    it('should call DELETE /api/session/:id/participate/:userId and delete a user from a session', () => {
+      service.unParticipate('1','3').subscribe((result) => {
+        expect(result).toBeUndefined();
+      });
+
+      const req = httpTestingController.expectOne('api/session/1/participate/3');
+      expect(req.request.method).toBe('DELETE');
+      req.flush(null);
+    });
+
+    it('should handle a bad request error on DELETE /api/session/:id/participate/:userId with wrong userId', () => {
+      service.unParticipate('1', 'abc').subscribe({
+        next: () => {
+          throw new Error('Expected an error, but got a response');
+        },
+        error: (error) => {
+          expect(error.status).toBe(400);
+          expect(error.statusText).toBe('Bad Request');
+        }
+      });
+
+      const req = httpTestingController.expectOne('api/session/1/participate/abc');
+      expect(req.request.method).toBe('DELETE');
+      req.flush('Invalid user ID', { status: 400, statusText: 'Bad Request' });
+    });
+
+    it('should handle a session not found error on DELETE /api/session/:id/participate/:userId', () => {
+      service.unParticipate('9999', '3').subscribe({
+        next: () => {
+          throw new Error('Expected an error, but got a response');
+        },
+        error: (error) => {
+          expect(error.status).toBe(404);
+          expect(error.statusText).toBe('Not Found');
+        }
+      });
+
+      const req = httpTestingController.expectOne('api/session/9999/participate/3');
+      expect(req.request.method).toBe('DELETE');
+      req.flush('Session not found', { status: 404, statusText: 'Not Found' });
+    });
+
+    it('should handle a user not found error on DELETE /api/session/:id/participate/:userId', () => {
+      service.unParticipate('1', '9999').subscribe({
+        next: () => {
+          throw new Error('Expected an error, but got a response');
+        },
+        error: (error) => {
+          expect(error.status).toBe(404);
+          expect(error.statusText).toBe('Not Found');
+        }
+      });
+
+      const req = httpTestingController.expectOne('api/session/1/participate/9999');
+      expect(req.request.method).toBe('DELETE');
+      req.flush('Session not found', { status: 404, statusText: 'Not Found' });
+    });
   });
 });

--- a/front/src/app/mocks/auth.mocks.ts
+++ b/front/src/app/mocks/auth.mocks.ts
@@ -1,0 +1,14 @@
+import { LoginRequest } from '../features/auth/interfaces/loginRequest.interface';
+import { RegisterRequest } from '../features/auth/interfaces/registerRequest.interface';
+
+export const mockRegisterRequest: RegisterRequest = { 
+  email: 'claire@perret.com',
+  firstName: 'Claire',
+  lastName: 'Perret',
+  password: 'password'
+};
+
+export const mockLoginRequest: LoginRequest = { 
+  email: 'claire@perret.com',
+  password: 'password'
+};

--- a/front/src/app/mocks/session.information.mocks.ts
+++ b/front/src/app/mocks/session.information.mocks.ts
@@ -1,0 +1,11 @@
+import { SessionInformation } from '../interfaces/sessionInformation.interface';
+
+export const mockSessionInformation: SessionInformation = { 
+  token: 'token',
+  type: 'type',
+  id: 1,
+  username: 'claire@perret.com',
+  firstName: 'Claire',
+  lastName: 'Perret',
+  admin: false
+};

--- a/front/src/app/mocks/session.mocks.ts
+++ b/front/src/app/mocks/session.mocks.ts
@@ -1,0 +1,45 @@
+import { Session } from '../features/sessions/interfaces/session.interface';
+
+export const mockSession: Session = {
+  id: 1,
+  name: 'Session',
+  description: 'A session description',
+  date: new Date(),
+  teacher_id: 1,
+  users: [1, 2],
+  createdAt: new Date('2025-02-12T14:00:00'),
+  updatedAt: new Date('2025-02-12T15:00:00')
+};
+
+export const mockSessions: Session[] = [
+  {
+    id: 1,
+    name: 'Session 1',
+    description: 'A session description 1',
+    date: new Date(),
+    teacher_id: 1,
+    users: [1, 2],
+    createdAt: new Date('2025-02-15T14:00:00'),
+    updatedAt: new Date('2025-02-18T15:00:00')
+  },
+  {
+    id: 2,
+    name: 'Session 2',
+    description: 'A session description 2',
+    date: new Date(),
+    teacher_id: 1,
+    users: [3, 4],
+    createdAt: new Date('2025-02-20T14:00:00'),
+    updatedAt: new Date('2025-02-21T16:00:00')
+  },
+  {
+    id: 3,
+    name: 'Session 3',
+    description: 'A session description 3',
+    date: new Date(),
+    teacher_id: 1,
+    users: [5, 6],
+    createdAt: new Date('2025-02-24T14:00:00'),
+    updatedAt: new Date('2025-02-26T17:00:00')
+  }
+];

--- a/front/src/app/mocks/teacher.mocks.ts
+++ b/front/src/app/mocks/teacher.mocks.ts
@@ -1,0 +1,33 @@
+import { Teacher } from '../interfaces/teacher.interface';
+
+export const mockTeacher: Teacher = {
+  id: 1,
+  lastName: 'Anna',
+  firstName: 'Perret',
+  createdAt: new Date('2025-01-25T14:00:00'),
+  updatedAt: new Date('2025-01-26T15:00:00')
+};
+
+export const mockTeachers: Teacher[] = [
+  {
+    id: 1,
+    lastName: 'Jean',
+    firstName: 'Dupont',
+    createdAt: new Date('2025-01-25T14:00:00'),
+    updatedAt: new Date('2025-01-26T15:00:00')
+  },
+  {
+    id: 2,
+    lastName: 'Thomas',
+    firstName: 'Martin',
+    createdAt: new Date('2025-01-25T14:00:00'),
+    updatedAt: new Date('2025-01-27T16:00:00')
+  },
+  {
+    id: 3,
+    lastName: 'Claire',
+    firstName: 'Beaumont',
+    createdAt: new Date('2025-01-25T14:00:00'),
+    updatedAt: new Date('2025-01-28T17:00:00')
+  }
+];

--- a/front/src/app/mocks/user.mocks.ts
+++ b/front/src/app/mocks/user.mocks.ts
@@ -1,0 +1,11 @@
+import { User } from '../interfaces/user.interface';
+
+export const mockUser: User = {
+  id: 1,
+  email: 'anna@perret.com',
+  lastName: 'Perret',
+  firstName: 'Anna',
+  admin: false,
+  password: 'password',
+  createdAt: new Date('2025-08-25T14:00:00'),
+};

--- a/front/src/app/services/session.service.spec.ts
+++ b/front/src/app/services/session.service.spec.ts
@@ -1,8 +1,9 @@
 import { TestBed } from '@angular/core/testing';
 import { expect } from '@jest/globals';
-import { SessionInformation } from '../interfaces/sessionInformation.interface';
-import { SessionService } from './session.service';
 import { firstValueFrom } from 'rxjs';
+
+import { SessionService } from './session.service';
+import { mockSessionInformation } from '../mocks/session.information.mocks';
 
 describe('SessionService', () => {
   let service: SessionService;
@@ -16,7 +17,7 @@ describe('SessionService', () => {
     expect(service).toBeTruthy();
   });
 
-  it('initial state should be false or undefined', async () => {
+  it('should initialize with logged out state', async () => {
     expect(service.isLogged).toBeFalsy();
     expect(service.sessionInformation).toBeUndefined();
 
@@ -24,17 +25,7 @@ describe('SessionService', () => {
     expect(value).toBe(false);
   });
 
-  it('should do login with mockSessionInformation and return true', async () => {
-    const mockSessionInformation: SessionInformation = { 
-      token: 'token',
-      type: 'type',
-      id: 1,
-      username: 'claire@perret.com',
-      firstName: 'Claire',
-      lastName: 'Perret',
-      admin: false
-    };
-
+  it('should do login with session information and return true', async () => {
     service.logIn(mockSessionInformation);
     
     expect(service.isLogged).toBe(true);
@@ -44,17 +35,7 @@ describe('SessionService', () => {
     expect(value).toBe(true);
   });
 
-  it('should do logout with mockSessionInformation and return false for $isLogged', async () => {
-    const mockSessionInformation: SessionInformation = { 
-      token: 'token',
-      type: 'type',
-      id: 1,
-      username: 'claire@perret.com',
-      firstName: 'Claire',
-      lastName: 'Perret',
-      admin: false
-    };
-
+  it('should do logout and update logged state to false', async () => {
     service.logIn(mockSessionInformation);
     service.logOut();
     

--- a/front/src/app/services/user.service.spec.ts
+++ b/front/src/app/services/user.service.spec.ts
@@ -1,56 +1,111 @@
-import { HttpClientModule, HttpClient } from '@angular/common/http';
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 import { TestBed } from '@angular/core/testing';
-import { of } from 'rxjs';
-import { expect, jest } from '@jest/globals';
+import { expect } from '@jest/globals';
 
 import { UserService } from './user.service';
-import { User } from '../interfaces/user.interface';
+import { mockUser } from '../mocks/user.mocks';
 
 describe('UserService', () => {
   let service: UserService;
-  let httpClient: HttpClient;
+  let httpTestingController: HttpTestingController;
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports:[
-        HttpClientModule
+      imports: [
+        HttpClientTestingModule
       ]
     });
+
     service = TestBed.inject(UserService);
-    httpClient = TestBed.inject(HttpClient);
+    httpTestingController = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpTestingController.verify();
   });
 
   it('should be created', () => {
     expect(service).toBeTruthy();
   });
- 
+
   it('should call GET /api/user/:id and return a user', () => {
-    const mockUser: User = { 
-      id: 1, 
-      email: 'anna@perret.com', 
-      lastName: 'Perret', 
-      firstName: 'Anna', 
-      admin: false, 
-      password: 'password', 
-      createdAt: new Date()
-    };
-
-    const httpGetSpy = jest.spyOn(httpClient, 'get').mockReturnValue(of(mockUser));
-
-    service.getById('1').subscribe((result) => {
-      expect(result).toEqual(mockUser);
+    service.getById('1').subscribe((user) => {
+      expect(user).toEqual(mockUser);
     });
 
-    expect(httpGetSpy).toHaveBeenCalledWith('api/user/1');
+    const req = httpTestingController.expectOne('api/user/1');
+    expect(req.request.method).toBe('GET');
+    req.flush(mockUser);
+  });
+
+  it('should handle wrong id on GET /api/user/:id', () => {
+    service.getById('abc').subscribe({
+      next: () => {
+        throw new Error('Expected an error, but got a response');
+      },
+      error: (error) => {
+        expect(error.status).toBe(400);
+        expect(error.statusText).toBe('Bad Request');
+      }
+    });
+
+    const req = httpTestingController.expectOne('api/user/abc');
+    expect(req.request.method).toBe('GET');
+    req.flush('Bad Request', { status: 400, statusText: 'Bad Request' });
+  });
+
+  it('should handle 404 error on GET /api/user/:id when user not found', () => {
+    service.getById('9999').subscribe({
+      next: () => {
+        throw new Error('Expected an error, but got a response');
+      },
+      error: (error) => {
+        expect(error.status).toBe(404);
+      }
+    });
+
+    const req = httpTestingController.expectOne('api/user/9999');
+    req.flush('User not found', { status: 404, statusText: 'Not Found' });
   });
 
   it('should call DELETE /api/user/:id and return null', () => {
-    const httpDeleteSpy = jest.spyOn(httpClient, 'delete').mockReturnValue(of(null));
-
-    service.delete('1').subscribe((result) => {
-      expect(result).toBeNull();
+    service.delete('1').subscribe((response) => {
+      expect(response).toBeNull();
     });
 
-    expect(httpDeleteSpy).toHaveBeenCalledWith('api/user/1');
+    const req = httpTestingController.expectOne('api/user/1');
+    expect(req.request.method).toBe('DELETE');
+    req.flush(null);
+  });
+
+  it('should handle wrong id on DELETE /api/user/:id', () => {
+    service.delete('abc').subscribe({
+      next: () => {
+        throw new Error('Expected an error, but got a response');
+      },
+      error: (error) => {
+        expect(error.status).toBe(400);
+      }
+    });
+
+    const req = httpTestingController.expectOne('api/user/abc');
+    expect(req.request.method).toBe('DELETE');
+    req.flush('Bad Request', { status: 400, statusText: 'Bad Request' });
+  });
+
+  it('should handle 404 error on DELETE /api/user/:id when user not found', () => {
+    service.delete('9999').subscribe({
+      next: () => {
+        throw new Error('Expected an error, but got a response');
+      },
+      error: (error) => {
+        expect(error.status).toBe(404);
+        expect(error.statusText).toBe('Not Found');
+      }
+    });
+
+    const req = httpTestingController.expectOne('api/user/9999');
+    expect(req.request.method).toBe('DELETE');
+    req.flush('User not found', { status: 404, statusText: 'Not Found' });
   });
 });


### PR DESCRIPTION
- Extend Jest unit tests for services with error cases
- Refactor unit tests to use HttpClientTestingModule and HttpTestingController
- Add mocks for services