### PR TITLE
Remove redundant session creation and unify command chaining syntax

### DIFF
--- a/front/cypress/e2e/detail.cy.ts
+++ b/front/cypress/e2e/detail.cy.ts
@@ -144,9 +144,9 @@ describe('Detail spec', () => {
 
     cy.url().should('include', '/sessions/detail/1')
 
-    cy.get('h1').contains('Session 1').should('be.visible')
-    cy.get('.ml1').contains('2 attendees').should('be.visible')
-    cy.get('.description').contains('Description: A description').should('be.visible')
+    cy.contains('h1', 'Session 1').should('be.visible')
+    cy.contains('.ml1', '2 attendees').should('be.visible')
+    cy.contains('.description', 'Description: A description').should('be.visible')
     cy.get('.ml1').contains('July 25, 2025')
 
     cy.get('.created').contains('Create at: May 1, 2025')
@@ -176,7 +176,7 @@ describe('Detail spec', () => {
 
     cy.wait('@deleteSession')
 
-    cy.get('.mat-simple-snack-bar-content').contains('Session deleted !')
+    cy.contains('.mat-simple-snack-bar-content', 'Session deleted !')
 
     cy.url().should('include', '/sessions')
   });
@@ -267,9 +267,9 @@ describe('Detail spec', () => {
 
     cy.url().should('include', '/sessions/detail/1')
 
-    cy.get('h1').contains('Session 1').should('be.visible')
-    cy.get('.ml1').contains('2 attendees').should('be.visible')
-    cy.get('.description').contains('Description: A description').should('be.visible')
+    cy.contains('h1', 'Session 1').should('be.visible')
+    cy.contains('.ml1', '2 attendees').should('be.visible')
+    cy.contains('.description', 'Description: A description').should('be.visible')
     cy.get('.ml1').contains('July 25, 2025')
 
     cy.get('.created').contains('Create at: May 1, 2025')
@@ -345,9 +345,9 @@ describe('Detail spec', () => {
 
     cy.url().should('include', '/sessions/detail/1')
 
-    cy.get('h1').contains('Session 1').should('be.visible')
-    cy.get('.ml1').contains('2 attendees').should('be.visible')
-    cy.get('.description').contains('Description: A description').should('be.visible')
+    cy.contains('h1', 'Session 1').should('be.visible')
+    cy.contains('.ml1', '2 attendees').should('be.visible')
+    cy.contains('.description', 'Description: A description').should('be.visible')
     cy.get('.ml1').contains('July 25, 2025')
 
     cy.get('.created').contains('Create at: May 1, 2025')

--- a/front/cypress/e2e/form.cy.ts
+++ b/front/cypress/e2e/form.cy.ts
@@ -21,7 +21,7 @@ describe('Form spec', () => {
           name: 'Session 1',
           description: 'A description',
           date: '2025-07-22T12:00:00.000Z',
-          teacher_id: 2,
+          teacher_id: 1,
           users: [2, 3],
           createdAt: '2025-05-01T12:00:00.000Z',
           updatedAt: '2025-05-01T12:00:00.000Z'
@@ -35,154 +35,6 @@ describe('Form spec', () => {
     cy.get('input[formControlName=password]').type('test!1234{enter}{enter}')
 
     cy.url().should('include', '/sessions')
-    cy.intercept('GET', '/api/teacher', {
-      body: [
-        {
-          id: 1,
-          firstName: 'Claire',
-          lastName: 'Beaumont'
-        },
-        {
-          id: 2,
-          firstName: 'Jean',
-          lastName: 'Dupont'
-        }
-      ],
-    })
-
-    cy.contains('span.ml1', 'Create').click()
-
-    cy.url().should('include', '/sessions/create')
-
-    cy.get('h1').contains('Create session').should('be.visible')
-
-    cy.get('input[formControlName=name]').type('Session')
-    cy.get('input[formControlName=date]').type('2025-07-28')
-
-    cy.get('mat-select[formControlName=teacher_id]').click()
-    cy.get('mat-option').should('have.length.at.least', 2)
-    cy.get('mat-option').contains('Claire Beaumont').click()
-
-    cy.get('textarea[formControlName=description]').type('A short description')
-
-    cy.intercept('POST', '/api/session', {
-      body: {
-        id: 2,
-        name: 'sessionName',
-        description: 'description',
-        date: '2025-07-25T12:00:00.000Z',
-        teacher_id: 1,
-        users: [1, 2],
-        createdAt: '2025-05-01T12:00:00.000Z',
-        updatedAt: '2025-05-01T12:00:00.000Z'
-      },
-    })
-
-    cy.intercept('GET', '/api/session', {
-      body: [
-        {
-          id: 1,
-          name: 'Session 1',
-          description: 'A description',
-          date: '2025-07-22T12:00:00.000Z',
-          teacher_id: 2,
-          users: [2, 3],
-          createdAt: '2025-05-01T12:00:00.000Z',
-          updatedAt: '2025-05-01T12:00:00.000Z'
-        },
-        {
-          id: 2,
-          name: 'Session 2',
-          description: 'A short description',
-          date: '2025-07-25T12:00:00.000Z',
-          teacher_id: 1,
-          users: [1, 2],
-          createdAt: '2025-05-01T12:00:00.000Z',
-          updatedAt: '2025-05-01T12:00:00.000Z'
-        }
-      ],
-    }).as('newSession')
-
-    cy.get('button').contains('Save').click()
-
-    cy.wait('@newSession')
-
-    cy.get('.mat-simple-snack-bar-content').contains('Session created !')
-
-    cy.url().should('include', '/sessions')
-  });
-
-  it('Validation when required fields are empty', () => {
-    cy.get('input[formControlName=email]').type('yoga@studio.com')
-    cy.get('input[formControlName=password]').type('test!1234{enter}{enter}')
-
-    cy.url().should('include', '/sessions')
-
-    cy.intercept('GET', '/api/teacher', {
-      body: [
-        {
-          id: 1,
-          firstName: 'Claire',
-          lastName: 'Beaumont'
-        },
-        {
-          id: 2,
-          firstName: 'Jean',
-          lastName: 'Dupont'
-        }
-      ],
-    })
-
-    cy.intercept(
-      {
-        method: 'POST',
-        url: '/api/session',
-      },
-      [])
-
-    cy.contains('span.ml1', 'Create').click()
-
-    cy.url().should('include', '/sessions/create')
-
-    cy.get('input[formControlName=name]').click().blur()
-    cy.get('input[formControlName=name]').should('have.class', 'ng-touched').and('have.class', 'ng-invalid')
-
-    cy.get('input[formControlName=date]').click().blur()
-    cy.get('input[formControlName=date]').should('have.class', 'ng-touched').and('have.class', 'ng-invalid')
-
-    cy.get('mat-select[formControlName=teacher_id]').click().blur()
-    cy.get('body').click(0, 0).blur()
-    cy.get('mat-select[formControlName=teacher_id]').should('have.class', 'ng-touched').and('have.class', 'ng-invalid')
-
-    cy.get('textarea[formControlName=description]').click().blur()
-    cy.get('textarea[formControlName=description]').should('have.class', 'ng-touched').and('have.class', 'ng-invalid')
-
-    cy.intercept('GET', '/api/session', {
-      body: [
-        {
-          id: 1,
-          name: 'Session 1',
-          description: 'A description',
-          date: '2025-07-22T12:00:00.000Z',
-          teacher_id: 2,
-          users: [2, 3],
-          createdAt: '2025-05-01T12:00:00.000Z',
-          updatedAt: '2025-05-01T12:00:00.000Z'
-        }
-      ],
-    })
-
-    cy.get('.mat-icon').click()
-
-    cy.url().should('include', '/sessions')
-  });
-
-  it('Update session success', () => {
-    cy.get('input[formControlName=email]').type('yoga@studio.com')
-    cy.get('input[formControlName=password]').type('test!1234{enter}{enter}')
-
-    cy.url().should('include', '/sessions')
-
     cy.intercept('GET', '/api/teacher', {
       body: [
         {
@@ -249,22 +101,121 @@ describe('Form spec', () => {
           updatedAt: '2025-05-01T12:00:00.000Z'
         }
       ],
-    })
+    }).as('newSession')
 
     cy.get('button').contains('Save').click()
 
-    cy.get('.mat-simple-snack-bar-content').contains('Session created !')
+    cy.wait('@newSession')
+
+    cy.contains('.mat-simple-snack-bar-content', 'Session created !')
 
     cy.url().should('include', '/sessions')
+  });
+
+  it('Validation when required fields are empty', () => {
+    cy.get('input[formControlName=email]').type('yoga@studio.com')
+    cy.get('input[formControlName=password]').type('test!1234{enter}{enter}')
+
+    cy.url().should('include', '/sessions')
+
+    cy.intercept('GET', '/api/teacher', {
+      body: [
+        {
+          id: 1,
+          firstName: 'Claire',
+          lastName: 'Beaumont'
+        },
+        {
+          id: 2,
+          firstName: 'Jean',
+          lastName: 'Dupont'
+        }
+      ],
+    })
+
+    cy.intercept(
+      {
+        method: 'POST',
+        url: '/api/session',
+      },
+      [])
+
+    cy.contains('span.ml1', 'Create').click()
+
+    cy.url().should('include', '/sessions/create')
+
+    cy.get('input[formControlName=name]').click().blur()
+    cy.get('input[formControlName=name]').should('have.class', 'ng-touched').and('have.class', 'ng-invalid')
+
+    cy.get('input[formControlName=date]').click().blur()
+    cy.get('input[formControlName=date]').should('have.class', 'ng-touched').and('have.class', 'ng-invalid')
+
+    cy.get('mat-select[formControlName=teacher_id]').click().blur()
+    cy.get('body').click(0, 0).blur()
+    cy.get('mat-select[formControlName=teacher_id]').should('have.class', 'ng-touched').and('have.class', 'ng-invalid')
+
+    cy.get('textarea[formControlName=description]').click().blur()
+    cy.get('textarea[formControlName=description]').should('have.class', 'ng-touched').and('have.class', 'ng-invalid')
+
+    cy.intercept('GET', '/api/session', {
+      body: [
+        {
+          id: 1,
+          name: 'Session 1',
+          description: 'A description',
+          date: '2025-07-22T12:00:00.000Z',
+          teacher_id: 2,
+          users: [2, 3],
+          createdAt: '2025-05-01T12:00:00.000Z',
+          updatedAt: '2025-05-01T12:00:00.000Z'
+        },
+        {
+          id: 2,
+          name: 'Session 2',
+          description: 'A short description',
+          date: '2025-07-25T12:00:00.000Z',
+          teacher_id: 1,
+          users: [1, 2],
+          createdAt: '2025-05-01T12:00:00.000Z',
+          updatedAt: '2025-05-01T12:00:00.000Z'
+        }
+      ],
+    })
+
+    cy.get('.mat-icon').click()
+
+    cy.url().should('include', '/sessions')
+  });
+
+  it('Update session success', () => {
+    cy.get('input[formControlName=email]').type('yoga@studio.com')
+    cy.get('input[formControlName=password]').type('test!1234{enter}{enter}')
+
+    cy.url().should('include', '/sessions')
+
+    cy.intercept('GET', '/api/teacher', {
+      body: [
+        {
+          id: 1,
+          firstName: 'Claire',
+          lastName: 'Beaumont'
+        },
+        {
+          id: 2,
+          firstName: 'Jean',
+          lastName: 'Dupont'
+        }
+      ],
+    })
 
     cy.intercept('GET', '/api/session/1', {
       body: {
         id: 1,
-        name: 'sessionName',
-        description: 'description',
-        date: '2025-07-25T12:00:00.000Z',
+        name: 'Session 1',
+        description: 'A description',
+        date: '2025-07-22T12:00:00.000Z',
         teacher_id: 1,
-        users: [1, 2],
+        users: [2, 3],
         createdAt: '2025-05-01T12:00:00.000Z',
         updatedAt: '2025-05-01T12:00:00.000Z'
       },
@@ -287,12 +238,12 @@ describe('Form spec', () => {
 
     cy.intercept('PUT', '/api/session/1', {
       body: {
-        id: 2,
-        name: 'sessionName',
-        description: 'description',
-        date: '2025-07-25T12:00:00.000Z',
-        teacher_id: 1,
-        users: [1, 2],
+        id: 1,
+        name: 'Updated session',
+        description: 'An updated description',
+        date: '2025-07-30T12:00:00.000Z',
+        teacher_id: 2,
+        users: [2, 3],
         createdAt: '2025-05-01T12:00:00.000Z',
         updatedAt: '2025-05-01T12:00:00.000Z'
       },
@@ -304,28 +255,17 @@ describe('Form spec', () => {
           id: 1,
           name: 'Updated session',
           description: 'An updated description',
-          date: '2025-07-24T12:00:00.000Z',
-          teacher_id: 1,
+          date: '2025-07-30T12:00:00.000Z',
+          teacher_id: 2,
           users: [2, 3],
-          createdAt: '2025-05-01T12:00:00.000Z',
-          updatedAt: '2025-05-01T12:00:00.000Z'
-        },
-        {
-          id: 2,
-          name: 'Session 2',
-          description: 'An short description',
-          date: '2025-07-28T12:00:00.000Z',
-          teacher_id: 1,
-          users: [1, 2],
           createdAt: '2025-05-01T12:00:00.000Z',
           updatedAt: '2025-05-01T12:00:00.000Z'
         }
       ],
     })
 
-    cy.get('button').contains('Save').click()
-
-    cy.get('.mat-simple-snack-bar-content').contains('Session updated !')
+    cy.contains('button', 'Save').click()
+    cy.contains('.mat-simple-snack-bar-content', 'Session updated !')
 
     cy.url().should('include', '/sessions')
   });

--- a/front/cypress/e2e/login.cy.ts
+++ b/front/cypress/e2e/login.cy.ts
@@ -33,7 +33,7 @@ describe('Login spec', () => {
     cy.get('input[formControlName=email]').type('yoga@studio.com')
     cy.get('input[formControlName=password]').type('password{enter}{enter}')
 
-    cy.get('.error').should('be.visible').and('contain', 'An error occurred')
+    cy.contains('.error', 'An error occurred').should('be.visible')
 
     cy.url().should('include', '/login')
   });

--- a/front/cypress/e2e/me.cy.ts
+++ b/front/cypress/e2e/me.cy.ts
@@ -38,13 +38,13 @@ describe('Me spec', () => {
 
     cy.url().should('include', '/me')
 
-    cy.get('h1').should('contain.text', 'User information').should('be.visible')
-    cy.get('p').should('contain.text', 'Name: Admin ADMIN').should('be.visible')
-    cy.get('p').should('contain.text', 'Email: yoga@studio.com').should('be.visible')
-    cy.get('.my2').should('contain.text', 'You are admin').should('be.visible')
+    cy.contains('h1', 'User information').should('be.visible')
+    cy.contains('p', 'Name: Admin ADMIN').should('be.visible')
+    cy.contains('p', 'Email: yoga@studio.com').should('be.visible')
+    cy.contains('.my2', 'You are admin').should('be.visible')
 
-    cy.get('.p2').should('contain.text', 'April 1, 2025').should('be.visible')
-    cy.get('.p2').should('contain.text', 'April 3, 2025').should('be.visible')
+    cy.contains('.p2', 'April 1, 2025').should('be.visible')
+    cy.contains('.p2', 'April 3, 2025').should('be.visible')
 
     cy.get('mat-icon').click()
 
@@ -85,15 +85,15 @@ describe('Me spec', () => {
 
     cy.url().should('include', '/me')
 
-    cy.get('h1').should('contain.text', 'User information').should('be.visible')
-    cy.get('p').should('contain.text', 'Name: User USER').should('be.visible')
-    cy.get('p').should('contain.text', 'Email: user@studio.com').should('be.visible')
+    cy.contains('h1', 'User information').should('be.visible')
+    cy.contains('p', 'Name: User USER').should('be.visible')
+    cy.contains('p', 'Email: user@studio.com').should('be.visible')
 
-    cy.get('.my2 > p').should('contain.text', 'Delete my account:').should('be.visible')
-    cy.get('.ml1').should('contain.text', 'Detail').should('be.visible')
+    cy.contains('.my2 > p', 'Delete my account:').should('be.visible')
+    cy.contains('.ml1', 'Detail').should('be.visible')
 
-    cy.get('.p2').should('contain.text', 'April 1, 2025').should('be.visible')
-    cy.get('.p2').should('contain.text', 'April 3, 2025').should('be.visible')
+    cy.contains('.p2', 'April 1, 2025').should('be.visible')
+    cy.contains('.p2', 'April 3, 2025').should('be.visible')
 
     cy.intercept('DELETE', '/api/user/2', {
       body: {},
@@ -101,7 +101,7 @@ describe('Me spec', () => {
 
     cy.get('.my2 > .mat-focus-indicator').click()
 
-    cy.get('.mat-simple-snack-bar-content').should('contain.text', 'Your account has been deleted !')
+    cy.contains('.mat-simple-snack-bar-content', 'Your account has been deleted !')
 
     cy.url().should('eq', Cypress.config().baseUrl)
   });

--- a/front/cypress/e2e/not-found.cy.ts
+++ b/front/cypress/e2e/not-found.cy.ts
@@ -48,6 +48,6 @@ describe('NotFound spec', () => {
 
     cy.visit('/login/user')
 
-    cy.get('h1').should('be.visible').and('contain.text', 'Page not found !')
+    cy.contains('h1', 'Page not found !').should('be.visible')
   });
 });

--- a/front/cypress/e2e/register.cy.ts
+++ b/front/cypress/e2e/register.cy.ts
@@ -37,7 +37,7 @@ describe('Register spec', () => {
     cy.get('input[formControlName=email]').type('yoga@studio.com')
     cy.get('input[formControlName=password]').type('password{enter}{enter}')
 
-    cy.get('.error').should('be.visible').and('contain', 'An error occurred')
+    cy.contains('.error', 'An error occurred').should('be.visible')
 
     cy.url().should('include', '/register')
   });


### PR DESCRIPTION
- Remove redundant session creation in 'Update session success' test
- Unify command chaining syntax across E2E tests